### PR TITLE
Add new source and input for ESRI World Water layer

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -18,8 +18,4 @@ jobs:
       run: pip install flake8 flake8-nb
     - name: run flake8 ⚙️
       run: |
-        find . -type f -name "*.py" | xargs flake8 --max-line-length=88 --ignore=E203,E701,W503 --exclude=./IO/Scripts/old/*
-    - name: run flake8-notebook ⚙️
-      if: '!cancelled()'
-      run: |
-        find . -type f -name "*.ipynb" -not -path "./IO/Scripts/old/*" | xargs flake8-nb --max-line-length=88 --ignore=E203,E701,W503
+        find . -type f -name "*.py" | xargs flake8 --max-line-length=88 --ignore=E203,E701,W503

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.12
         architecture: x64
     - name: Checkout repository
       uses: actions/checkout@master

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@master
     - name: Install flake8
-      run: pip install flake8 flake8-nb
+      run: pip install flake8==7.3.0
     - name: run flake8 ⚙️
       run: |
         find . -type f -name "*.py" | xargs flake8 --max-line-length=88 --ignore=E203,E701,W503

--- a/IO/Scripts/Modules/vectors.py
+++ b/IO/Scripts/Modules/vectors.py
@@ -5,9 +5,7 @@ import pandas as pd
 import geopandas as gpd
 import osmnx as ox
 import shapely
-from arcgis.gis import GIS
 from arcgis.features import FeatureLayer
-from arcgis.geometry.filters import overlaps
 import duckdb
 import os
 import io
@@ -439,21 +437,22 @@ def water_dwnld_clean(
         lakes = ovrtr_memry(lkCols, lkDPath, lkQuer, xmin, xmax, ymin, ymax, con)
 
         # esri water
-        lpk_url = "https://www.arcgis.com/sharing/rest/content/items/e750071279bf450cbd510454a80f2e63/data"
+        lpk_url = (
+            "https://www.arcgis.com/sharing/rest/content/items/"
+            + "e750071279bf450cbd510454a80f2e63/data"
+        )
         ewCols = ["OBJECTID", "Name1", "TYPE", "ISO_CC", "geometry"]
         bbox_filter = (xmin, ymin, xmax, ymax)
-    
-    
+
         response = requests.get(lpk_url)
         lpk_bytes = io.BytesIO(response.content)
-    
+
         # Extract and process using a temporary directory
         with tempfile.TemporaryDirectory() as temp_dir:
-        # Unzip the 7z archive
-            with py7zr.SevenZipFile(lpk_bytes, mode='r') as z:
+            # Unzip the 7z archive
+            with py7zr.SevenZipFile(lpk_bytes, mode="r") as z:
                 z.extractall(path=temp_dir)
-    
-            
+
             gdb_path = None
             for root, dirs, _ in os.walk(temp_dir):
                 for d in dirs:
@@ -462,25 +461,26 @@ def water_dwnld_clean(
                         gdb_path = os.path.join(root, d)
                         print(f"Found GDB at: {gdb_path}")
                         break
-                if gdb_path: break
-    
+                if gdb_path:
+                    break
+
             if not gdb_path:
                 raise FileNotFoundError("ESRI world water could not be fetched.")
-    
+
             # Read the GDB into a GeoDataFrame
             water = gpd.read_file(
                 gdb_path,
                 columns=ewCols,
-                bbox=bbox_filter,
+                bbox=bbox_filter,  # type: ignore
                 engine="pyogrio",
-                on_invalid="ignore"
+                on_invalid="ignore",
             )
-    
+
         if not water.empty:
-            water['geometry'] = water.geometry.make_valid()
-    
+            water["geometry"] = water.geometry.make_valid()
+
         water = water[water.geometry.area > 0.001]
-    
+
         water = water.to_crs("EPSG:4326")
 
         # buffer rivers

--- a/IO/Scripts/Modules/vectors.py
+++ b/IO/Scripts/Modules/vectors.py
@@ -9,6 +9,11 @@ from arcgis.gis import GIS
 from arcgis.features import FeatureLayer
 from arcgis.geometry.filters import overlaps
 import duckdb
+import os
+import io
+import py7zr
+import tempfile
+import requests
 
 
 def ox_trans_load(
@@ -434,22 +439,49 @@ def water_dwnld_clean(
         lakes = ovrtr_memry(lkCols, lkDPath, lkQuer, xmin, xmax, ymin, ymax, con)
 
         # esri water
-        ewCols = ["objectid", "name1", "type", "iso_cc"]
-        ewDPath = "https://maps.nccs.nasa.gov/mapping/rest/services/base_layers/esri_world_water_bodies/FeatureServer/0"  # noqa
-        agol = GIS()  # noqa
-        query_extent: dict[str, np.float64 | dict[str, int]] = {
-            "xmin": xmin,
-            "ymin": ymin,
-            "xmax": xmax,
-            "ymax": ymax,
-            "spatialReference": {"wkid": 4326},
-        }
-        water = FeatureLayer(ewDPath).query(
-            where="SHAPE__Area > 0.001",
-            geometry_filter=overlaps(query_extent, sr=4326),  # type: ignore
-            as_df=True,
-        )
-        water = fl_2_gdf(water, cols=ewCols, espg="EPSG:4326")  # type: ignore
+        lpk_url = "https://www.arcgis.com/sharing/rest/content/items/e750071279bf450cbd510454a80f2e63/data"
+        ewCols = ["OBJECTID", "Name1", "TYPE", "ISO_CC", "geometry"]
+        bbox_filter = (xmin, ymin, xmax, ymax)
+    
+    
+        response = requests.get(lpk_url)
+        lpk_bytes = io.BytesIO(response.content)
+    
+        # Extract and process using a temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+        # Unzip the 7z archive
+            with py7zr.SevenZipFile(lpk_bytes, mode='r') as z:
+                z.extractall(path=temp_dir)
+    
+            
+            gdb_path = None
+            for root, dirs, _ in os.walk(temp_dir):
+                for d in dirs:
+                    # Case-insensitive check for .gdb folders
+                    if d.lower().endswith(".gdb"):
+                        gdb_path = os.path.join(root, d)
+                        print(f"Found GDB at: {gdb_path}")
+                        break
+                if gdb_path: break
+    
+            if not gdb_path:
+                raise FileNotFoundError("ESRI world water could not be fetched.")
+    
+            # Read the GDB into a GeoDataFrame
+            water = gpd.read_file(
+                gdb_path,
+                columns=ewCols,
+                bbox=bbox_filter,
+                engine="pyogrio",
+                on_invalid="ignore"
+            )
+    
+        if not water.empty:
+            water['geometry'] = water.geometry.make_valid()
+    
+        water = water[water.geometry.area > 0.001]
+    
+        water = water.to_crs("EPSG:4326")
 
         # buffer rivers
         rivers = rivers.to_crs(wkid)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "whitebox>=2.3.6",
     "xarray-spatial>=0.4.0",
+    "py7zr>=1.1.2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
# Description

Add new source and input for ESRI World Water layer

# Changes Made

Uses ESRI .lpk file for world water sources; NASA feature server is deprecated

Downloads and unzips file from URL, filtering and clipping the water to relevant area, projects CRS to EPSG:4326. 7z util needed and added to .toml.

# Related Issues

Issue #2 
